### PR TITLE
[refactor] Member 리팩토링

### DIFF
--- a/src/main/java/me/jh9/wantedpreonboarding/common/BaseEntity.java
+++ b/src/main/java/me/jh9/wantedpreonboarding/common/BaseEntity.java
@@ -1,0 +1,40 @@
+package me.jh9.wantedpreonboarding.common;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Column(updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedAt;
+
+    private boolean isDeleted = false;
+
+    public void delete() {
+        isDeleted = true;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getLastModifiedAt() {
+        return lastModifiedAt;
+    }
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+}

--- a/src/main/java/me/jh9/wantedpreonboarding/config/AuditingEntityConfig.java
+++ b/src/main/java/me/jh9/wantedpreonboarding/config/AuditingEntityConfig.java
@@ -1,0 +1,10 @@
+package me.jh9.wantedpreonboarding.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class AuditingEntityConfig {
+
+}

--- a/src/main/java/me/jh9/wantedpreonboarding/member/api/MemberController.java
+++ b/src/main/java/me/jh9/wantedpreonboarding/member/api/MemberController.java
@@ -3,6 +3,8 @@ package me.jh9.wantedpreonboarding.member.api;
 import jakarta.validation.Valid;
 import me.jh9.wantedpreonboarding.member.api.request.LoginRequest;
 import me.jh9.wantedpreonboarding.member.api.request.SignUpRequest;
+import me.jh9.wantedpreonboarding.member.application.response.LoginResponse;
+import me.jh9.wantedpreonboarding.member.application.request.LoginServiceRequest;
 import me.jh9.wantedpreonboarding.member.application.response.MemberResponse;
 import me.jh9.wantedpreonboarding.member.application.usecase.LoginUseCase;
 import me.jh9.wantedpreonboarding.member.application.usecase.SignUpUseCase;
@@ -35,9 +37,10 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<MemberResponse> login(@RequestBody@Valid LoginRequest request) {
+    public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
             .contentType(MediaType.APPLICATION_JSON)
-            .body(loginUseCase.login(request.toServiceRequest()));
+            .body(loginUseCase
+                .login(new LoginServiceRequest(request.email(), request.password())));
     }
 }

--- a/src/main/java/me/jh9/wantedpreonboarding/member/api/MemberControllerAdvice.java
+++ b/src/main/java/me/jh9/wantedpreonboarding/member/api/MemberControllerAdvice.java
@@ -23,4 +23,10 @@ public class MemberControllerAdvice {
             .body(new ErrorResponse(
                 exception.getMessage()));
     }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> runtimeException(RuntimeException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse(exception.getMessage()));
+    }
 }

--- a/src/main/java/me/jh9/wantedpreonboarding/member/application/MemberService.java
+++ b/src/main/java/me/jh9/wantedpreonboarding/member/application/MemberService.java
@@ -1,46 +1,80 @@
 package me.jh9.wantedpreonboarding.member.application;
 
+import me.jh9.wantedpreonboarding.common.jwt.application.usecase.AccessTokenUseCase;
+import me.jh9.wantedpreonboarding.common.jwt.application.usecase.RefreshTokenUseCase;
 import me.jh9.wantedpreonboarding.member.application.request.LoginServiceRequest;
 import me.jh9.wantedpreonboarding.member.application.request.SignUpServiceRequest;
+import me.jh9.wantedpreonboarding.member.application.response.LoginResponse;
+import me.jh9.wantedpreonboarding.member.application.response.LoginResponse.JwtFair;
 import me.jh9.wantedpreonboarding.member.application.response.MemberResponse;
 import me.jh9.wantedpreonboarding.member.application.usecase.LoginUseCase;
 import me.jh9.wantedpreonboarding.member.application.usecase.SignUpUseCase;
 import me.jh9.wantedpreonboarding.member.domain.Member;
 import me.jh9.wantedpreonboarding.member.infra.MemberRepository;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(readOnly = true)
 @Service
-public class MemberService implements LoginUseCase, SignUpUseCase {
+public class MemberService implements SignUpUseCase, LoginUseCase {
 
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AccessTokenUseCase accessTokenUseCase;
+    private final RefreshTokenUseCase refreshTokenUseCase;
 
-    public MemberService(MemberRepository memberRepository) {
+    public MemberService(MemberRepository memberRepository, AccessTokenUseCase accessTokenUseCase,
+        RefreshTokenUseCase refreshTokenUseCase) {
         this.memberRepository = memberRepository;
+        this.passwordEncoder = new BCryptPasswordEncoder();
+        this.accessTokenUseCase = accessTokenUseCase;
+        this.refreshTokenUseCase = refreshTokenUseCase;
     }
 
     @Transactional
     @Override
     public MemberResponse signUp(SignUpServiceRequest request) {
+
+        validateEmailExist(request);
+
         Member savedMember = memberRepository.save(
-            Member.createNewMember(request.email(), request.password()));
+            Member.createNewMember(request.email(), passwordEncoder.encode(request.password())));
 
         return MemberResponse.toDto(savedMember);
     }
 
-    @Override
-    public MemberResponse login(LoginServiceRequest request) {
-        Member member = memberRepository.findByEmail(request.email())
-            .orElseThrow(() -> new IllegalArgumentException("로그인 정보가 정확하지 않습니다."));
-
-        if (!isPasswordMatch(request.password(), member.getPassword())) {
-            throw new IllegalArgumentException("로그인 정보가 정확하지 않습니다.");
+    private void validateEmailExist(SignUpServiceRequest request) {
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new IllegalArgumentException("이미 존재하는 이메일 입니다.");
         }
-        return MemberResponse.toDto(member);
     }
 
-    private static boolean isPasswordMatch(String targetPassword, String actualPassword) {
-        return targetPassword.equals(actualPassword);
+    @Override
+    public LoginResponse login(LoginServiceRequest loginRequest) {
+        final String email = loginRequest.email();
+        final String inputPassword = loginRequest.password();
+
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new IllegalArgumentException("잘못된 로그인 정보입니다."));
+
+        validatePasswordMatch(inputPassword, member.getPassword());
+
+        return LoginResponse.toDto(member.getId(), createJwtFair(member.getId()));
+    }
+
+    private void validatePasswordMatch(String inputPassword, String realPassword) {
+        if (!passwordEncoder.matches(inputPassword, realPassword)) {
+            throw new IllegalArgumentException("잘못된 로그인 정보입니다.");
+        }
+    }
+
+    private JwtFair createJwtFair(Long memberId) {
+        String subject = String.valueOf(memberId);
+        String accessToken = accessTokenUseCase.createAccessToken(subject, System.currentTimeMillis());
+        String refreshToken = refreshTokenUseCase.createRefreshToken(subject, System.currentTimeMillis());
+
+        return new JwtFair(accessToken, refreshToken);
     }
 }

--- a/src/main/java/me/jh9/wantedpreonboarding/member/application/response/LoginResponse.java
+++ b/src/main/java/me/jh9/wantedpreonboarding/member/application/response/LoginResponse.java
@@ -1,0 +1,18 @@
+package me.jh9.wantedpreonboarding.member.application.response;
+
+public record LoginResponse(
+    Long memberId,
+    JwtFair jwtFair
+) {
+
+    public static LoginResponse toDto(Long memberId, JwtFair jwtFair) {
+        return new LoginResponse(memberId, jwtFair);
+    }
+
+    public record JwtFair(
+        String accessToken,
+        String refreshToken
+    ) {
+
+    }
+}

--- a/src/main/java/me/jh9/wantedpreonboarding/member/application/usecase/LoginUseCase.java
+++ b/src/main/java/me/jh9/wantedpreonboarding/member/application/usecase/LoginUseCase.java
@@ -1,9 +1,9 @@
 package me.jh9.wantedpreonboarding.member.application.usecase;
 
 import me.jh9.wantedpreonboarding.member.application.request.LoginServiceRequest;
-import me.jh9.wantedpreonboarding.member.application.response.MemberResponse;
+import me.jh9.wantedpreonboarding.member.application.response.LoginResponse;
 
 public interface LoginUseCase {
 
-    MemberResponse login(LoginServiceRequest request);
+    LoginResponse login(LoginServiceRequest request);
 }

--- a/src/main/java/me/jh9/wantedpreonboarding/member/domain/Member.java
+++ b/src/main/java/me/jh9/wantedpreonboarding/member/domain/Member.java
@@ -5,10 +5,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import me.jh9.wantedpreonboarding.common.BaseEntity;
 
 @Table(name = "members")
 @Entity
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/me/jh9/wantedpreonboarding/member/infra/MemberRepository.java
+++ b/src/main/java/me/jh9/wantedpreonboarding/member/infra/MemberRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/test/java/me/jh9/wantedpreonboarding/integration/member/MemberLoginTest.java
+++ b/src/test/java/me/jh9/wantedpreonboarding/integration/member/MemberLoginTest.java
@@ -1,0 +1,90 @@
+package me.jh9.wantedpreonboarding.integration.member;
+
+import java.util.Optional;
+import me.jh9.wantedpreonboarding.member.api.request.LoginRequest;
+import me.jh9.wantedpreonboarding.member.api.request.SignUpRequest;
+import me.jh9.wantedpreonboarding.member.application.MemberService;
+import me.jh9.wantedpreonboarding.member.application.request.SignUpServiceRequest;
+import me.jh9.wantedpreonboarding.member.application.response.MemberResponse;
+import me.jh9.wantedpreonboarding.member.domain.Member;
+import me.jh9.wantedpreonboarding.member.infra.MemberRepository;
+import me.jh9.wantedpreonboarding.utils.IntegrationTestSupport;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+class MemberLoginTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("로그인을 성공할 수 있다.")
+    @Test
+    void signUpTest_willSuccess() {
+        // given
+        MemberResponse expectedResponse = memberService.signUp(
+            new SignUpServiceRequest("test@email.com", "myPassword1"));
+
+        LoginRequest request = new LoginRequest("test@email.com", "myPassword1");
+        String signUpURL = HOST + port + "/api/v1/member/login";
+
+        // when
+        ResponseEntity<MemberResponse> responseEntity = testRestTemplate
+            .postForEntity(signUpURL, request, MemberResponse.class);
+
+        // then
+        Assertions.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Assertions.assertThat(responseEntity.getBody()).isEqualTo(expectedResponse);
+        Assertions.assertThat(responseEntity.getHeaders().get(HttpHeaders.AUTHORIZATION))
+            .isNotNull();
+        Assertions.assertThat(responseEntity.getHeaders().get("refresh-token")).isNotNull();
+    }
+
+    @DisplayName("아이디가 이메일 포맷이 아니면 실패한다.")
+    @Test
+    void signUpTest_willFail() {
+        // given
+        String notEmailFormat = "myEmailtest.com";
+        LoginRequest badRequest = new LoginRequest(notEmailFormat, "myPassword1");
+
+        String signUpURL = HOST + port + "/api/v1/member/signUp";
+
+        // when
+        ResponseEntity<String> responseEntity = testRestTemplate.postForEntity(
+            signUpURL, badRequest, String.class);
+
+        Optional<Member> optionalMember = memberRepository.findByEmail(badRequest.email());
+
+        // then
+        Assertions.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        Assertions.assertThat(responseEntity.getBody()).isEqualTo("{\"message\":\"아이디는 이메일 형식어야 합니다.\"}");
+        Assertions.assertThat(optionalMember).isNotPresent();
+    }
+
+    @DisplayName("Password Encoding이 되어 있지 않으면 로그인에 실패한다.")
+    @Test
+    void notPasswordEncoded_willFail() {
+        // given
+        Member newMember = Member.createNewMember("myEmail@test.com", "myPassword1");
+        SignUpRequest request = new SignUpRequest("myEmail@test.com", "myPassword1");
+        String signUpURL = HOST + port + "/api/v1/member/login";
+
+        // when
+        ResponseEntity<String> responseEntity = testRestTemplate.postForEntity(
+            signUpURL, request, String.class);
+
+        Optional<Member> optionalMember = memberRepository.findByEmail(request.email());
+
+        // then
+        Assertions.assertThat(optionalMember).isNotPresent();
+        Assertions.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+//        Assertions.assertThat(responseEntity.getBody()).isEqualTo("");
+    }
+}

--- a/src/test/java/me/jh9/wantedpreonboarding/integration/member/MemberSignUpTest.java
+++ b/src/test/java/me/jh9/wantedpreonboarding/integration/member/MemberSignUpTest.java
@@ -1,0 +1,64 @@
+package me.jh9.wantedpreonboarding.integration.member;
+
+import java.util.Optional;
+import me.jh9.wantedpreonboarding.member.api.request.SignUpRequest;
+import me.jh9.wantedpreonboarding.member.application.MemberService;
+import me.jh9.wantedpreonboarding.member.application.response.MemberResponse;
+import me.jh9.wantedpreonboarding.member.domain.Member;
+import me.jh9.wantedpreonboarding.member.infra.MemberRepository;
+import me.jh9.wantedpreonboarding.utils.IntegrationTestSupport;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+class MemberSignUpTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("회원가입을 성공할 수 있다.")
+    @Test
+    void signUpTest_willSuccess() {
+        // given
+        SignUpRequest request = new SignUpRequest("myEmail@test.com", "myPassword1");
+        String signUpURL = HOST + port + "/api/v1/member/signUp";
+
+        // when
+        ResponseEntity<MemberResponse> responseEntity = testRestTemplate.postForEntity(
+            signUpURL, request, MemberResponse.class);
+
+        Member createdMember = memberRepository.findByEmail(request.email()).get();
+        MemberResponse expectedResponse = MemberResponse.toDto(createdMember);
+
+        // then
+        Assertions.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        Assertions.assertThat(responseEntity.getBody()).isEqualTo(expectedResponse);
+    }
+
+    @DisplayName("아이디가 이메일 포맷이 아니면 실패한다.")
+    @Test
+    void signUpTest_willFail() {
+        // given
+        String notEmailFormat = "myEmailtest.com";
+        SignUpRequest badRequest = new SignUpRequest(notEmailFormat, "myPassword1");
+
+        String signUpURL = HOST + port + "/api/v1/member/signUp";
+
+        // when
+        ResponseEntity<String> responseEntity = testRestTemplate.postForEntity(
+            signUpURL, badRequest, String.class);
+
+        Optional<Member> optionalMember = memberRepository.findByEmail(badRequest.email());
+
+        // then
+        Assertions.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        Assertions.assertThat(responseEntity.getBody()).isEqualTo("{\"message\":\"아이디는 이메일 형식어야 합니다.\"}");
+        Assertions.assertThat(optionalMember).isNotPresent();
+    }
+}

--- a/src/test/java/me/jh9/wantedpreonboarding/unit/member/application/MemberServiceTest.java
+++ b/src/test/java/me/jh9/wantedpreonboarding/unit/member/application/MemberServiceTest.java
@@ -1,16 +1,20 @@
 package me.jh9.wantedpreonboarding.unit.member.application;
 
 
+import static me.jh9.wantedpreonboarding.utils.member.TestMemberFactory.createTestMember;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
 import java.util.Optional;
 import me.jh9.wantedpreonboarding.member.application.request.LoginServiceRequest;
 import me.jh9.wantedpreonboarding.member.application.request.SignUpServiceRequest;
+import me.jh9.wantedpreonboarding.member.application.response.LoginResponse;
 import me.jh9.wantedpreonboarding.member.application.response.MemberResponse;
 import me.jh9.wantedpreonboarding.member.domain.Member;
 import me.jh9.wantedpreonboarding.utils.UnitTestSupport;
+import me.jh9.wantedpreonboarding.utils.fake.JwtFakeService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -24,9 +28,9 @@ class MemberServiceTest extends UnitTestSupport {
 
         @DisplayName("신규 유저를 생성할 수 있다.")
         @Test
-        void _willSuccess(){
+        void _willSuccess() {
             // given
-            Member createdMember = Member.createNewMember("email@test.com", "password");
+            Member createdMember = createTestMember();
             SignUpServiceRequest serviceRequest = new SignUpServiceRequest("email@test.com", "password");
 
             given(memberRepository.save(any(Member.class))).willReturn(createdMember);
@@ -47,50 +51,57 @@ class MemberServiceTest extends UnitTestSupport {
 
         @DisplayName("로그인을 할 수 있다.")
         @Test
-        void _willSuccess(){
+        void _willSuccess() {
             // given
-            Member createdMember = Member.createNewMember("email@test.com", "password");
-            LoginServiceRequest serviceRequest = new LoginServiceRequest(createdMember.getEmail(), createdMember.getPassword());
+            Member createdMember = createTestMember();
+            LoginServiceRequest serviceRequest = new LoginServiceRequest(createdMember.getEmail(),
+                "password");
 
             given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(createdMember));
+            given(jwtFakeService.createAccessToken(anyString(), anyLong())).willReturn(
+                JwtFakeService.FAKE_ACCESS_TOKEN);
+            given(jwtFakeService.createRefreshToken(anyString(), anyLong())).willReturn(
+                JwtFakeService.FAKE_REFRESH_TOKEN);
 
             // when
-            MemberResponse result = memberService.login(serviceRequest);
+            LoginResponse result = memberService.login(serviceRequest);
 
             // then
-            Assertions.assertThat(result)
-                .extracting("id", "email")
-                .containsExactly(null, createdMember.getEmail());
+            Assertions.assertThat(result.jwtFair())
+                .extracting("accessToken", "refreshToken")
+                .containsExactly(JwtFakeService.FAKE_ACCESS_TOKEN, JwtFakeService.FAKE_REFRESH_TOKEN);
         }
 
         @DisplayName("존재하지 않는 Email이면 로그인에 실패한다.")
         @Test
-        void nowhereEmail_willFail(){
+        void nowhereEmail_willFail() {
             // given
-            Member createdMember = Member.createNewMember("email@test.com", "password");
-            LoginServiceRequest noWhereEmailRequest = new LoginServiceRequest("email1@test.com", "password");
+            Member createdMember = createTestMember();
+            LoginServiceRequest noWhereEmailRequest = new LoginServiceRequest("email1@test.com",
+                "password");
 
             given(memberRepository.save(any(Member.class))).willReturn(createdMember);
 
             // when then
             Assertions.assertThatThrownBy(() -> memberService.login(noWhereEmailRequest))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("로그인 정보가 정확하지 않습니다.");
+                .hasMessage("잘못된 로그인 정보입니다.");
         }
 
         @DisplayName("비밀번호가 정확하지 않으면 로그인에 실패한다.")
         @Test
-        void notMatchPassword_willFail(){
+        void notMatchPassword_willFail() {
             // given
-            Member createdMember = Member.createNewMember("email@test.com", "password");
-            LoginServiceRequest notMatchPasswordRequest = new LoginServiceRequest("email1@test.com", "password123");
+            Member createdMember = createTestMember();
+            LoginServiceRequest notMatchPasswordRequest = new LoginServiceRequest("email1@test.com",
+                "password123");
 
             given(memberRepository.save(any(Member.class))).willReturn(createdMember);
 
             // when then
             Assertions.assertThatThrownBy(() -> memberService.login(notMatchPasswordRequest))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("로그인 정보가 정확하지 않습니다.");
+                .hasMessage("잘못된 로그인 정보입니다.");
         }
     }
 }

--- a/src/test/java/me/jh9/wantedpreonboarding/unit/member/domain/MemberTest.java
+++ b/src/test/java/me/jh9/wantedpreonboarding/unit/member/domain/MemberTest.java
@@ -1,7 +1,5 @@
 package me.jh9.wantedpreonboarding.unit.member.domain;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import me.jh9.wantedpreonboarding.member.domain.Member;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/me/jh9/wantedpreonboarding/unit/member/infra/MemberRepositoryTest.java
+++ b/src/test/java/me/jh9/wantedpreonboarding/unit/member/infra/MemberRepositoryTest.java
@@ -6,7 +6,6 @@ import me.jh9.wantedpreonboarding.member.domain.Member;
 import me.jh9.wantedpreonboarding.member.infra.MemberRepository;
 import me.jh9.wantedpreonboarding.utils.IntegrationTestSupport;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/me/jh9/wantedpreonboarding/utils/RepositoryTestSupport.java
+++ b/src/test/java/me/jh9/wantedpreonboarding/utils/RepositoryTestSupport.java
@@ -1,9 +1,8 @@
 package me.jh9.wantedpreonboarding.utils;
 
-import me.jh9.wantedpreonboarding.article.repository.ArticleRepository;
+import me.jh9.wantedpreonboarding.article.infra.ArticleRepository;
 import me.jh9.wantedpreonboarding.common.jwt.infra.RedisJwtRepository;
 import me.jh9.wantedpreonboarding.member.infra.MemberRepository;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;

--- a/src/test/java/me/jh9/wantedpreonboarding/utils/UnitTestSupport.java
+++ b/src/test/java/me/jh9/wantedpreonboarding/utils/UnitTestSupport.java
@@ -1,14 +1,18 @@
 package me.jh9.wantedpreonboarding.utils;
 
 import me.jh9.wantedpreonboarding.article.application.ArticleService;
-import me.jh9.wantedpreonboarding.article.repository.ArticleRepository;
+import me.jh9.wantedpreonboarding.article.infra.ArticleRepository;
 import me.jh9.wantedpreonboarding.member.application.MemberService;
 import me.jh9.wantedpreonboarding.member.infra.MemberRepository;
+import me.jh9.wantedpreonboarding.utils.config.UnitTestConfig;
+import me.jh9.wantedpreonboarding.utils.fake.JwtFakeService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+@Import(UnitTestConfig.class)
 @ActiveProfiles("test")
 @SpringBootTest
 public abstract class UnitTestSupport {
@@ -24,4 +28,7 @@ public abstract class UnitTestSupport {
 
     @Mock
     protected MemberRepository memberRepository;
+
+    @Mock
+    protected JwtFakeService jwtFakeService;
 }

--- a/src/test/java/me/jh9/wantedpreonboarding/utils/member/TestMemberFactory.java
+++ b/src/test/java/me/jh9/wantedpreonboarding/utils/member/TestMemberFactory.java
@@ -1,0 +1,16 @@
+package me.jh9.wantedpreonboarding.utils.member;
+
+import me.jh9.wantedpreonboarding.member.domain.Member;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class TestMemberFactory {
+
+    private static final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    @NotNull
+    public static Member createTestMember() {
+        return Member.createNewMember("email@test.com", passwordEncoder.encode("password"));
+    }
+}


### PR DESCRIPTION
* Member -> baseEntity 추가
* MemberResponse -> JWT를 가지는 LoginResponse로 변경
* test코드 추가

MemberRepository.java
* count(*)를 수행하는 existsByEmail() 추가

MemberService.java
* Security 적용으로 인해 PasswordEncoder 추가
* Token 부여 기능 추가
* email 중복 검증 추가